### PR TITLE
Cambios en la configuración de Hibernate y script de inserción de datos al iniciar el proyecto 

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,12 @@ spring.datasource.password= admin
 spring.jpa.properties.hibernate.dialect= org.hibernate.dialect.MySQLDialect
 
 # Hibernate ddl auto (create, create-drop, validate, update)
-spring.jpa.hibernate.ddl-auto= update 
+#actualiza la base de datos cada vez que se encuentra un cambio
+#spring.jpa.hibernate.ddl-auto= update
+#crea la base de datos cada vez que se ejecuta el proyecto con los datos que se encuentran en el archivo import .sql
+spring.jpa.hibernate.ddl-auto=create
+
+
 
 # spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
@@ -16,5 +21,5 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.servlet.multipart.max-file-size=10MB 
 #tamaño maximo de la peticion
 spring.servlet.multipart.max-request-size=10MB 
-```
+
 

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -1,0 +1,10 @@
+--  Script para insertar datos en la base de datos, se ejecuta al iniciar la aplicación porque está configurado en el archivo application.properties con la propiedad spring.jpa.hibernate.ddl-auto=create
+
+INSERT INTO roles (id,nombre)VALUES (1,"Usuario");
+INSERT INTO roles (id,nombre)VALUES (2,"Administrador");
+
+INSERT INTO estados (id,nombre)VALUES (1,true);
+INSERT INTO estados (id,nombre)VALUES (2,false);
+
+
+


### PR DESCRIPTION
Este pull request incluye cambios en la configuración de Hibernate para utilizar "spring.jpa.hibernate.ddl-auto=create" y un script "import.sql" para insertar datos en la base de datos al iniciar el proyecto. 
Estos cambios permiten que la base de datos se actualice automáticamente y se inserten datos adicionales al iniciar la aplicación. Se han realizado pruebas locales para verificar el funcionamiento correcto de estos cambios